### PR TITLE
Migrate from deprecated ReactDOM.render to createRoot

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createGlobalStyle } from 'styled-components'
 import 'normalize.css'
 import 'font-awesome/css/font-awesome.css'
@@ -20,10 +20,9 @@ const GlobalStyle = createGlobalStyle`
   }
 `
 
-render(
+createRoot(document.getElementById('app')!).render(
   <>
     <GlobalStyle />
     <App />
-  </>,
-  document.getElementById('app')
+  </>
 )


### PR DESCRIPTION
## Summary

Fixes the deprecated React API usage — the second checklist section of #69.

`src/main.tsx` used `render` from `react-dom`, which is deprecated in React 18 and runs the app in React 17 compatibility mode. It now uses `createRoot` from `react-dom/client`, the React 18 root API.

## Testing

- `pnpm lint` passes
- `pnpm build` completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia)_