### PR TITLE
Add dev script, fix start script, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 # MyResume
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/Naturalclar/myResume.svg?token=99549a66397111f2e901a631ce718a4079b4851f7372bf118c510c21c1843534&ts=1563086591650)](https://greenkeeper.io/)
-
-MyResume, built with react.js
+MyResume, built with React and TypeScript, bundled with Vite.
 
 ## Getting Started
 
 ### Clone Repository
 
-`git clone`
+`git clone https://github.com/Naturalclar/myResume.git`
 
 ### Install Dependencies
 
 `pnpm install`
 
+### Develop with Live Reloading
+
+`pnpm dev`
+
 ### Bundle Files
 
 `pnpm build`
 
-### Display it on local browser
+### Preview the Production Build
 
 `pnpm start`
 
-### Edit files with Live Reloading
+### Lint
 
-`pnpm watch`
+`pnpm lint`

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "dev": "vite",
     "build": "vite build",
-    "start": "vite serve dist",
+    "start": "vite preview",
     "lint": "oxlint src"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Developer-experience fixes from the checklist in #69 (section 4).

## Changes

- **Added `"dev": "vite"`** — there was previously no way to run the HMR dev server via a script (the README pointed at the broken gulp `watch` task)
- **Fixed `start`** — `vite serve dist` started a *dev server* rooted at the dist folder; it's now `vite preview`, the proper way to serve the production build
- **Rewrote the README** — removed the dead Greenkeeper badge and the broken `pnpm watch` instructions, and documented the actual scripts (`dev`, `build`, `start`, `lint`)

## Testing

- `pnpm dev` serves the app with HMR on :5173 (verified with curl)
- `pnpm build` + `pnpm start` serves the built site on :4173 (verified with curl)
- `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia)_