### PR TITLE
Modernize TypeScript setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,7 @@ jobs:
         run: pnpm install
       - name: Run lint
         run: pnpm run lint
+      - name: Run typecheck
+        run: pnpm run typecheck
       - name: Run build
         run: pnpm run build

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,5 +5,8 @@
     "correctness": "error",
     "suspicious": "warn"
   },
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  },
   "ignorePatterns": ["dist"]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "vite build",
     "start": "vite preview",
-    "lint": "oxlint src"
+    "lint": "oxlint src",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "font-awesome": "^4.7.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Header from './Header'
 import Summary from './Summary'
 import Experience from './Experience'

--- a/src/components/Education/index.tsx
+++ b/src/components/Education/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import { Article, SectionHeader, Icon } from '../Styles'
 import EducationMd from './education.md'

--- a/src/components/Experience/index.tsx
+++ b/src/components/Experience/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import { Article, SectionHeader, Icon } from '../Styles'
 import Experience1 from './cureapp-full-stack-engineer.md'

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import HeaderMd from './header.md'
 

--- a/src/components/Skill/Skill.tsx
+++ b/src/components/Skill/Skill.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { FC } from 'react'
 import styled from 'styled-components'
 import { SkillBar, SkillProgress } from '../Styles'
 
@@ -11,7 +11,7 @@ type Props = {
   name: string
   percent: number
 }
-const Skill: React.FC<Props> = ({ name, percent }) => {
+const Skill: FC<Props> = ({ name, percent }) => {
   const max = 220
   const min = 100
   const level = (min + (max - min) * (percent / 100)).toFixed()

--- a/src/components/Skill/SkillList.tsx
+++ b/src/components/Skill/SkillList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type { FC } from 'react'
 import styled from 'styled-components'
 import Skill from './Skill'
 import { SectionHeader, Icon } from '../Styles'
@@ -19,7 +19,7 @@ type Props = {
   skills: Skill[]
 }
 
-const SkillList: React.FC<Props> = ({ skills }) => (
+const SkillList: FC<Props> = ({ skills }) => (
   <Container>
     <SectionHeader>
       <Icon className="fa fa-code" />

--- a/src/components/Summary/index.tsx
+++ b/src/components/Summary/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { SectionHeader, Icon } from '../Styles'
 import SummaryMd from './summary.md'
 

--- a/src/components/_Frame.tsx
+++ b/src/components/_Frame.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { PrimaryBorder, GrayBorder } from './Styles'
 
 const Frame = () => (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { createGlobalStyle } from 'styled-components'
 import 'normalize.css'

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,4 +1,5 @@
 declare module '*.md' {
-  const value: string
-  export default value
+  import type { ComponentType } from 'react'
+  const MDXComponent: ComponentType<Record<string, unknown>>
+  export default MDXComponent
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "strict": true /* Enable all strict type-checking options. */,
-    "jsx": "react",
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-  }
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "useDefineForClassFields": true
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Modernizes the TypeScript configuration — section 3 of #69. Until now nothing typechecked this codebase (Vite only transpiles); with this PR `tsc` runs in full strict mode, locally and in CI, and passes clean.

## Changes

- **`tsconfig.json` rewritten for Vite**: `ESNext` target/module, `moduleResolution: "bundler"`, the automatic `react-jsx` transform, `noEmit`, `isolatedModules`, and full strict mode with proper DOM/ESNext libs — replacing the old ES5/CommonJS config
- **Dropped `import React from 'react'` from all components** — unnecessary with the automatic JSX runtime, which `@vitejs/plugin-react` already compiles with (the output bundle is byte-identical). The two `React.FC` usages became type-only `import type { FC }` imports
- **Fixed the `*.md` module declaration**: it claimed the default export was a `string`, but the files are imported as MDX React components — now typed as `ComponentType`
- **Added a `typecheck` script (`tsc`)** and a CI step running it between lint and build
- **Disabled oxlint's `react-in-jsx-scope` rule**, obsolete with the automatic JSX runtime

## Testing

- `pnpm lint` passes with no warnings
- `pnpm typecheck` passes (strict mode)
- `pnpm build` completes cleanly with an unchanged bundle hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia)_