### PR TITLE
Content cleanup: inline SVG icons, prune unused resume data

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "font-awesome": "^4.7.0",
     "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      font-awesome:
-        specifier: ^4.7.0
-        version: 4.7.0
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1116,10 +1113,6 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  font-awesome@4.7.0:
-    resolution: {integrity: sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==}
-    engines: {node: '>=0.10.3'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -2676,8 +2669,6 @@ snapshots:
       '@types/estree': 1.0.9
 
   extend@3.0.2: {}
-
-  font-awesome@4.7.0: {}
 
   fraction.js@5.3.4: {}
 

--- a/src/components/Education/index.tsx
+++ b/src/components/Education/index.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
-import { Article, SectionHeader, Icon } from '../Styles'
+import { Article, SectionHeader } from '../Styles'
+import { Icon } from '../Icon'
 import EducationMd from './education.md'
 
 const Container = styled.div`
@@ -9,7 +10,7 @@ const Container = styled.div`
 const Education = () => (
   <Container>
     <SectionHeader>
-      <Icon className="fa fa-graduation-cap" />
+      <Icon name="graduation-cap" />
       Education
     </SectionHeader>
     <Article>

--- a/src/components/Experience/index.tsx
+++ b/src/components/Experience/index.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
-import { Article, SectionHeader, Icon } from '../Styles'
+import { Article, SectionHeader } from '../Styles'
+import { Icon } from '../Icon'
 import Experience1 from './cureapp-full-stack-engineer.md'
 import Experience2 from './sai-jr-developer.md'
 
@@ -10,7 +11,7 @@ const Container = styled.div`
 const Experience = () => (
   <Container>
     <SectionHeader>
-      <Icon className="fa fa-suitcase" />
+      <Icon name="suitcase" />
       Work Experience
     </SectionHeader>
     <Article>

--- a/src/components/Experience/sai-qa-analyst.md
+++ b/src/components/Experience/sai-qa-analyst.md
@@ -1,5 +1,0 @@
-##### April 2014 - April 2016
-
-**Systena America Inc. San Mateo, CA** - _QA Engineer_
-
-- Performed quality assurance test on Android mobile phones and fiercely checked for UI/UX issues with preloaded applications.

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,0 +1,65 @@
+import type { FC, ReactNode } from 'react'
+import styled from 'styled-components'
+import { PrimaryColor } from './Styles/variables'
+
+const IconCircle = styled.span`
+  height: 32px;
+  width: 32px;
+  margin-right: 8px;
+  background: ${PrimaryColor};
+  color: white;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`
+
+export type IconName = 'user' | 'code' | 'graduation-cap' | 'suitcase'
+
+// Stroke paths adapted from Feather Icons (MIT) / Lucide (ISC)
+const paths: Record<IconName, ReactNode> = {
+  user: (
+    <>
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </>
+  ),
+  code: (
+    <>
+      <polyline points="16 18 22 12 16 6" />
+      <polyline points="8 6 2 12 8 18" />
+    </>
+  ),
+  'graduation-cap': (
+    <>
+      <path d="M21.42 10.92a1 1 0 0 0-.02-1.84L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.83l8.57 3.91a2 2 0 0 0 1.66 0z" />
+      <path d="M22 10v6" />
+      <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" />
+    </>
+  ),
+  suitcase: (
+    <>
+      <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+      <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+    </>
+  ),
+}
+
+export const Icon: FC<{ name: IconName }> = ({ name }) => (
+  <IconCircle>
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {paths[name]}
+    </svg>
+  </IconCircle>
+)

--- a/src/components/Skill/SkillList.tsx
+++ b/src/components/Skill/SkillList.tsx
@@ -1,7 +1,8 @@
 import type { FC } from 'react'
 import styled from 'styled-components'
 import Skill from './Skill'
-import { SectionHeader, Icon } from '../Styles'
+import { SectionHeader } from '../Styles'
+import { Icon } from '../Icon'
 
 const Container = styled.div`
   grid-area: skills;
@@ -22,7 +23,7 @@ type Props = {
 const SkillList: FC<Props> = ({ skills }) => (
   <Container>
     <SectionHeader>
-      <Icon className="fa fa-code" />
+      <Icon name="code" />
       Skills
     </SectionHeader>
     <ul>

--- a/src/components/Styles/sectionStyle.ts
+++ b/src/components/Styles/sectionStyle.ts
@@ -10,19 +10,6 @@ export const SectionHeader = styled.div`
   color: ${PrimaryColor};
 `
 
-export const Icon = styled.i`
-  height: 32px;
-  width: 32px;
-  margin-right: 8px;
-  background: ${PrimaryColor};
-  color: white;
-  border-radius: 16px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-`
-
 export const Article = styled.article`
   & h5 {
     color: silver;

--- a/src/components/Summary/index.tsx
+++ b/src/components/Summary/index.tsx
@@ -1,10 +1,11 @@
-import { SectionHeader, Icon } from '../Styles'
+import { SectionHeader } from '../Styles'
+import { Icon } from '../Icon'
 import SummaryMd from './summary.md'
 
 const Summary = () => (
   <article className="summary">
     <SectionHeader>
-      <Icon className="fa fa-user" />
+      <Icon name="user" />
       Summary
     </SectionHeader>
     <div>

--- a/src/imports/skills.ts
+++ b/src/imports/skills.ts
@@ -26,16 +26,8 @@ const skills: Record<string, Skill[]> = {
       percent: 80,
     },
     {
-      name: 'Babel(ES6)',
-      percent: 70,
-    },
-    {
       name: 'Node.js',
       percent: 70,
-    },
-    {
-      name: 'Rails 5',
-      percent: 50,
     },
     {
       name: 'HTML5',
@@ -44,10 +36,6 @@ const skills: Record<string, Skill[]> = {
     {
       name: 'CSS3',
       percent: 90,
-    },
-    {
-      name: 'jQuery',
-      percent: 80,
     },
     {
       name: 'Express.js',
@@ -58,78 +46,12 @@ const skills: Record<string, Skill[]> = {
       percent: 80,
     },
     {
-      name: 'Gulp',
-      percent: 60,
-    },
-    {
       name: 'Git',
       percent: 90,
     },
     {
       name: 'Python',
       percent: 70,
-    },
-  ],
-  'data-analyst': [
-    {
-      name: 'MySQL',
-      percent: 70,
-    },
-    {
-      name: 'MongoDB',
-      percent: 50,
-    },
-    {
-      name: 'Python',
-      percent: 70,
-    },
-    {
-      name: 'Japanese',
-      percent: 90,
-    },
-    {
-      name: 'Translation',
-      percent: 80,
-    },
-    {
-      name: 'HTML5',
-      percent: 90,
-    },
-    {
-      name: 'CSS3',
-      percent: 90,
-    },
-    {
-      name: 'Javascript',
-      percent: 80,
-    },
-    {
-      name: 'React',
-      percent: 75,
-    },
-    {
-      name: 'TypeScript',
-      percent: 60,
-    },
-    {
-      name: 'Node.js',
-      percent: 70,
-    },
-    {
-      name: 'Gulp',
-      percent: 60,
-    },
-    {
-      name: 'Git',
-      percent: 90,
-    },
-    {
-      name: 'Ruby',
-      percent: 40,
-    },
-    {
-      name: 'Rails 5',
-      percent: 40,
     },
   ],
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import { createGlobalStyle } from 'styled-components'
 import 'normalize.css'
-import 'font-awesome/css/font-awesome.css'
 import './styles.css'
 import App from './components/App'
 


### PR DESCRIPTION
## Summary

Content cleanup — section 6 of #69.

## Changes

- **Replace font-awesome with inline SVGs**: a new `src/components/Icon.tsx` renders the four section icons (user, code, graduation-cap, suitcase) as stroke SVGs adapted from Feather/Lucide, styled with the same blue-circle treatment as before. This removes the font-awesome v4 dependency (2016), dropping ~950 kB of webfont files from `dist` and shrinking the CSS bundle from 30.8 kB to 2.5 kB
- **Delete `sai-qa-analyst.md`** — never imported or rendered (recoverable from git history)
- **Remove the unused `data-analyst` skill set** — `App.tsx` hardcodes the `front-end-developer` category
- **Trim dated skill entries** (jQuery, Rails 5, Babel(ES6), Gulp); the remaining 12 keep their existing ratings — worth a personal review pass since the ratings are self-assessment

## Testing

- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` all pass
- `pnpm build` completes cleanly (no webfont assets in `dist`, CSS 30.8 kB → 2.5 kB)
- Visually verified via `vite preview` + headless Chromium screenshot: all four icons render crisply, layout intact, global styles applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia)_