### PR TITLE
Refresh CLAUDE.md to match the modernized repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,26 +8,27 @@ A single-page personal resume site built with Vite, React 18, TypeScript, styled
 
 ## Commands
 
-Uses pnpm (CI runs pnpm 8 on Node 20).
+Uses pnpm 10 (pinned via the `packageManager` field; Node 20 per Volta/engines).
 
 - `pnpm install` — install dependencies
-- `pnpm build` — production build via Vite (outputs to `dist/`)
-- `pnpm start` — serve the built `dist/` locally
-- `pnpm lint` — ESLint over `src` (`.ts`/`.tsx`), config extends `@naturalclar`
-- `npx vite` — dev server with HMR (there is no `dev` script in package.json)
+- `pnpm dev` — Vite dev server with HMR
+- `pnpm build` — production build (outputs to `dist/`)
+- `pnpm start` — preview the built `dist/` via `vite preview`
+- `pnpm lint` — oxlint over `src` (config in `.oxlintrc.json`)
+- `pnpm typecheck` — `tsc` in strict mode, no emit
+- `pnpm format` / `pnpm format:check` — Prettier write/check over the repo
 
-There are no tests; CI (`.github/workflows/ci.yml`) only runs `pnpm build` on pull requests, so a successful build is the bar for CI.
-
-Note: `pnpm watch` is a legacy gulp/webpack task and is broken — `gulpfile.js` requires a `webpack.config.js` that no longer exists. Use Vite instead.
+There are no tests; CI (`.github/workflows/ci.yml`) runs lint, format check, typecheck, and build on pull requests — all four must pass. Dependabot files grouped weekly update PRs.
 
 ## Architecture
 
-- Vite's `root` is `src/` (see `vite.config.js`), so `src/index.html` is the entry page and the build output goes to `../dist`. `src/main.tsx` mounts `App` into `#app` and sets global styles.
-- **Content lives in Markdown, not JSX.** Each resume section (`src/components/Header`, `Summary`, `Experience`, `Education`) colocates `.md` files with its `index.tsx` and imports them as React components via `@mdx-js/rollup` (with `remark-gfm`), registered as a `pre` plugin in `vite.config.js`. To change resume text, edit the `.md` files; to add an experience entry, add a `.md` file and import/render it in `Experience/index.tsx`. The `*.md` module declaration is in `src/typings/index.d.ts`.
+- Vite's `root` is `src/` (see `vite.config.js`), so `src/index.html` is the entry page and the build output goes to `../dist`. `src/main.tsx` creates the React root and renders a styled-components `createGlobalStyle` alongside `App`.
+- **Content lives in Markdown, not JSX.** Each resume section (`src/components/Header`, `Summary`, `Experience`, `Education`) colocates `.md` files with its `index.tsx` and imports them as React components via `@mdx-js/rollup` (with `remark-gfm`), registered as a `pre` plugin in `vite.config.js`. To change resume text, edit the `.md` files; to add an experience entry, add a `.md` file and import/render it in `Experience/index.tsx`. The `*.md` module declaration (typed as a React `ComponentType`) is in `src/typings/index.d.ts`.
 - **Skills are data-driven.** `src/imports/skills.ts` exports skill lists (name + percent) keyed by category; `App.tsx` picks one via its `category` constant and passes it to `SkillList`, which renders percentage bar graphs.
-- Shared styled-components (section headers, articles, icons, graph/border styles, variables) live in `src/components/Styles` and are re-exported from its `index.ts`.
-- Overall page layout (the two-column letter grid) is in `src/styles.css` plus `grid-area` assignments in each section's styled container.
+- **Section icons are inline SVGs** in `src/components/Icon.tsx` (a name-keyed set of stroke paths); there is no icon font.
+- Shared styled-components (section headers, articles, graph/border styles, variables) live in `src/components/Styles` and are re-exported from its `index.ts`.
+- Overall page layout (the two-column letter grid) is in `src/styles.css` plus `grid-area` assignments in each section's styled container. `styles.css` uses `@custom-media` queries and CSS nesting, compiled by `postcss-preset-env` (`postcss.config.cjs`).
 
 ## Code Style
 
-Prettier: no semicolons, single quotes, 2-space indent, ES5 trailing commas (`prettier.config.js`).
+Prettier: no semicolons, single quotes, 2-space indent, ES5 trailing commas (`prettier.config.js`, ESM). Prettier is enforced in CI — run `pnpm format` before committing. TypeScript is strict with the automatic JSX runtime: don't add `import React from 'react'`; use type-only imports for React types (e.g. `import type { FC } from 'react'`).


### PR DESCRIPTION
## Summary

Final item of #69 — closes it. The previous CLAUDE.md described the pre-cleanup repo: ESLint (broken, since replaced by oxlint), the gulp watch task, CI running only the build, and no dev script.

## Changes

- **Commands**: documents the full script set (`dev`, `build`, `start` via `vite preview`, `lint` via oxlint, `typecheck`, `format`/`format:check`) with the pnpm 10 / Node 20 pins
- **CI**: reflects the four gates (lint, format check, typecheck, build) and the grouped Dependabot updates
- **Architecture**: updated for `createRoot`, the `ComponentType`-typed MDX modules, the inline-SVG `Icon` component, and `postcss-preset-env` compiling the custom media queries/nesting in `styles.css`
- **Code style**: adds the new conventions — Prettier enforced in CI, strict TypeScript, automatic JSX runtime (no `import React`, type-only imports for React types)

## Testing

- `pnpm format:check` passes (CLAUDE.md is Prettier-clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaYDStop2ttXXtWNdnUfia)_